### PR TITLE
Refactor provider fixes

### DIFF
--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderCollision.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderCollision.cpp
@@ -84,6 +84,7 @@ bool URuntimeMeshProviderCollision::GetSectionMeshForLOD_Implementation(int32 LO
 	{
 		FRuntimeMeshRenderableCollisionData& SectionCacheData = RenderableCollisionData.FindOrAdd(SectionId);
 		SectionCacheData = FRuntimeMeshRenderableCollisionData(MeshData);
+		MarkCollisionDirty();
 	}
 
 	return bResult;
@@ -105,6 +106,7 @@ bool URuntimeMeshProviderCollision::GetAllSectionsMeshForLOD_Implementation(int3
 				SectionCacheData = FRuntimeMeshRenderableCollisionData(Entry.Value.MeshData);
 			}
 		}
+		MarkCollisionDirty();
 	}
 
 	return bResult;

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.h
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "RuntimeMesh.h"
 #include "RuntimeMeshSectionProxy.h"
 
 class UBodySetup;

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshCore.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshCore.cpp
@@ -214,6 +214,7 @@ FRuntimeMeshRenderableCollisionData::FRuntimeMeshRenderableCollisionData(const F
 
 	// Copy Triangles
 	int32 NumTriangles = InRenderable.Triangles.NumTriangles();
+	Triangles.SetNum( NumTriangles );
 	for (int32 Index = 0; Index < NumTriangles; Index++)
 	{
 		Triangles.SetTriangleIndices(Index,

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshProvider.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshProvider.cpp
@@ -332,7 +332,7 @@ void URuntimeMeshProviderPassthrough::Initialize_Implementation()
 	URuntimeMeshProvider* ChildProviderTemp = GetChildProvider();
 	if (ChildProviderTemp)
 	{
-		ChildProviderTemp->Unlink();
+		ChildProviderTemp->Initialize_Implementation();
 	}
 }
 

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -7,7 +7,9 @@
 #include "EngineGlobals.h"
 #include "Engine/StaticMesh.h"
 #include "PhysicsEngine/BodySetup.h"
-#include "../Public/RuntimeMeshRenderable.h"
+#include "RuntimeMeshRenderable.h"
+#include "RuntimeMeshComponent.h"
+#include "Providers/RuntimeMeshProviderStatic.h"
 
 
 int32 URuntimeMeshStaticMeshConverter::CopyVertexOrGetIndex(const FStaticMeshLODResources& LOD, const FStaticMeshSection& Section, TMap<int32, int32>& MeshToSectionVertexMap, int32 VertexIndex, FRuntimeMeshRenderableMeshData& NewMeshData)


### PR DESCRIPTION
Fixes:
- missing includes
- typo in RuntimeMeshProvider not calling Initialize_Implementation()
- FRuntimeMeshRenderableCollisionData not initializing triangles correctly and running into an array-out-of-bounds
- Properly calling MarkCollisionDirty() in the collisionProvider if the collisionDataCache is updated