### PR TITLE
Adding method SetShouldSerializeMeshData() to static mesh provider

### DIFF
--- a/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
+++ b/Source/RuntimeMeshComponent/Private/Providers/RuntimeMeshProviderStatic.cpp
@@ -290,6 +290,11 @@ FRuntimeMeshRenderableMeshData URuntimeMeshProviderStatic::GetSectionRenderDataA
 	return MeshData;
 }
 
+void URuntimeMeshProviderStatic::SetShouldSerializeMeshData(bool bIsSerialized)
+{
+	StoreEditorGeneratedDataForGame = bIsSerialized;
+}
+
 void URuntimeMeshProviderStatic::Initialize()
 {
 	RMC_LOG_VERBOSE("Initializing...");

--- a/Source/RuntimeMeshComponent/Public/Providers/RuntimeMeshProviderStatic.h
+++ b/Source/RuntimeMeshComponent/Public/Providers/RuntimeMeshProviderStatic.h
@@ -317,6 +317,9 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "RuntimeMesh|Providers|Static")
 	FRuntimeMeshRenderableMeshData GetSectionRenderDataAndClear(int32 LODIndex, int32 SectionId);
+	
+	UFUNCTION(BlueprintCallable, Category = "RuntimeMesh|Providers|Static")
+	void SetShouldSerializeMeshData(bool bIsSerialized);
 
 
 public:


### PR DESCRIPTION
Adding method SetShouldSerializeMeshData() to control whether mesh data should be serialized with the asset.

Without this the size of levels will bloat up with complex RMC actors.