### PR TITLE
RayTracing check fixed.

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshProxy.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshProxy.cpp
@@ -547,7 +547,9 @@ void FRuntimeMeshProxy::ApplyMeshToSection(int32 LODIndex, int32 SectionId, FRun
 		FRuntimeMeshSectionProxyBuffers& Buffers = *Section.Buffers.Get();
 
 		Buffers.VertexFactory.ReleaseResource();
+#if RHI_RAYTRACING
 		Buffers.RayTracingGeometry.ReleaseResource();
+#endif
 	}
 
 	check(!Section.CanRender() || Section.Buffers->VertexFactory.IsInitialized());


### PR DESCRIPTION
`RHI_RAYTRACING` macro should be checked before access `Buffers.RayTracingGeometry` .